### PR TITLE
feat!:Bump Python to 3.14, add v1 routes, use main

### DIFF
--- a/.github/CI_DOCUMENTATION.md
+++ b/.github/CI_DOCUMENTATION.md
@@ -8,7 +8,7 @@ Este documento descreve o fluxo de Integração Contínua (CI) e Entrega Contín
 
 Toda vez que uma alteração de código é enviada para a branch `master`, o GitHub Actions inicia automaticamente o workflow (`azure-identity` runner). O processo passa pelas seguintes etapas:
 
-1. **Checkout e Configuração:** Baixa o código mais recente e prepara o ambiente com Python 3.13.
+1. **Checkout e Configuração:** Baixa o código mais recente e prepara o ambiente com Python 3.14.
 2. **Testes Automatizados (CI):** Instala as dependências de teste e executa o `pytest`. Se os testes falharem, o pipeline é interrompido imediatamente, garantindo que código quebrado não seja publicado.
 3. **Versionamento (Bump Version):** Lê o histórico de commits, calcula automaticamente a próxima versão e cria uma nova Tag (ex: `v1.2.0`).
 4. **Build e Push (CD):** Faz login no Azure, constrói a imagem Docker da aplicação e faz o push para o ACR com duas tags: a versão específica gerada e a tag `latest`.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: CI - Test, Build and Release
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - '.github/workflows/**'
       - '**/*.md'
@@ -25,7 +25,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.13'
+        python-version: '3.14'
 
     - name: Install Dependencies and Run Tests
       run: |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Esta API fornece uma interface centralizada para o monitoramento contínuo de at
 
 ## 📋 Pré-requisitos
 
-- Python **3.13** instalado
+- Python **3.14** instalado
 - `pip` (gerenciador de pacotes do Python) atualizado
 
 ### Variáveis de Ambiente Necessárias

--- a/README_EN.md
+++ b/README_EN.md
@@ -29,7 +29,7 @@ This API provides a centralized interface for continuous monitoring of infrastru
 
 ## 📋 Requirements
 
-- Python **3.13**
+- Python **3.14**
 - `pip` (Python package manager)
 
 ### Required Environment Variables

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,12 @@ from api.v2 import generic_api_query
 
 app = FastAPI()
 
+# Version 1 of the API
+app.include_router(is_alive.router, prefix="/v1")
+app.include_router(mongo_health.router, prefix="/v1")
+app.include_router(generic_api_query.router, prefix="/v1")
+
+# Version 2 of the API
 app.include_router(is_alive.router, prefix="/v2")
 app.include_router(mongo_health.router, prefix="/v2")
 app.include_router(generic_api_query.router, prefix="/v2")


### PR DESCRIPTION
Update CI, docs and app to target Python 3.14 and switch workflow to the main branch. Changes include:
- .github/CI_DOCUMENTATION.md, README.md, README_EN.md: update references from Python 3.13 to 3.14.
- .github/workflows/release.yaml: run workflow on branch `main` (was `master`) and set actions/setup-python to 3.14.
- app/main.py: register is_alive, mongo_health and generic_api_query routers under the /v1 prefix (keeping existing /v2 registrations) to expose a v1 API surface.